### PR TITLE
Feature/delete saved covers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -15,10 +15,10 @@ var homeView = document.querySelector(".home-view");
 var savedView = document.querySelector(".saved-view");
 var formView = document.querySelector(".form-view");
 //Form/inputs HTML elements
-var inputCover = document.querySelector(".user-cover")
-var inputTitle = document.querySelector(".user-title");
-var inputDescriptor1 = document.querySelector(".user-desc1");
-var inputDescriptor2 = document.querySelector(".user-desc2");
+var inputCover = document.querySelector("#cover")
+var inputTitle = document.querySelector("#title");
+var inputDescriptor1 = document.querySelector("#descriptor1");
+var inputDescriptor2 = document.querySelector("#descriptor2");
 //Saved book covers/HTML elements
 var viewSavedCovers = document.querySelector(".saved-covers-section");
 //User's saved covers
@@ -27,7 +27,6 @@ var savedCovers = [
 ];
 //Holds cover instance
 var currentCover;
-
 
 // Event listeners
 window.addEventListener("load", createRandomCover);
@@ -64,6 +63,14 @@ function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
 };
 
+//Displays Cover instance on homepage
+function displayCover(cover) {
+  coverImage.src = cover.cover;
+  title.textContent = cover.title;
+  descriptor1.textContent = cover.tagline1;
+  descriptor2.textContent = cover.tagline2;
+};
+
 //Event handler for btnRandomCover
 function createRandomCover() {
   var coverInstance = covers[getRandomIndex(covers)];
@@ -76,14 +83,6 @@ function createRandomCover() {
   returnHome();
 };
 
-//Displays Cover instance on homepage
-function displayCover(cover) {
-  coverImage.src = cover.cover;
-  title.textContent = cover.title;
-  descriptor1.textContent = cover.tagline1;
-  descriptor2.textContent = cover.tagline2;
-};
-
 //Event handler for btnMakeNewCover
 function showForm() {
   leaveHome();
@@ -92,6 +91,21 @@ function showForm() {
   btnHome.classList.remove("hidden");
 };
 
+//Event handler for btnMakeMyBook
+function createNewCover(event) {
+  // Create new Cover instance using input values from form, display on home view
+  var createdCover = new Cover(inputCover.value, inputTitle.value, inputDescriptor1.value, inputDescriptor2.value);
+  displayCover(createdCover);
+  returnHome();
+  //Update arrays to include input values from form
+  covers.push(inputCover.value);
+  titles.push(inputTitle.value);
+  descriptors.push(inputDescriptor1.value);
+  descriptors.push(inputDescriptor2.value);
+  //Save created Cover to hidden array
+  currentCover = createdCover;
+  event.preventDefault();
+};
 
 //Event handler for btnViewSavedCover
 function showSaved() {
@@ -108,23 +122,6 @@ function showSaved() {
       <img class="overlay" src="./assets/overlay.png">
     </section>`;
     };
-};
-
-
-//Event handler for btnMakeMyBook
-function createNewCover(event) {
-  // Create new Cover instance using input values from form, display on home view
-  var createdCover = new Cover(inputCover.value, inputTitle.value, inputDescriptor1.value, inputDescriptor2.value);
-  displayCover(createdCover);
-  returnHome();
-  //Update arrays to include input values from form
-  covers.push(inputCover.value);
-  titles.push(inputTitle.value);
-  descriptors.push(inputDescriptor1.value);
-  descriptors.push(inputDescriptor2.value);
-  //Save created Cover to hidden array
-  currentCover = createdCover;
-  event.preventDefault();
 };
 
 //Checks user's cover for duplicates before adding to Saved Covers array

--- a/src/main.js
+++ b/src/main.js
@@ -132,3 +132,14 @@ function saveCover() {
     savedCovers.push(currentCover);
   };
 };
+
+//Event handler for deleting cover on dblclicking 
+function deleteSavedCovers(e) {
+var elementId = e.target.getAttribute("id");
+for (var i = 0; i < savedCovers.length; i++) {
+ if (savedCovers[i].id == elementId) {
+  savedCovers.splice(i, 1);
+  showSaved();
+ }
+}
+};

--- a/src/main.js
+++ b/src/main.js
@@ -21,10 +21,11 @@ var inputDescriptor1 = document.querySelector(".user-desc1");
 var inputDescriptor2 = document.querySelector(".user-desc2");
 //Saved book covers/HTML elements
 var viewSavedCovers = document.querySelector(".saved-covers-section");
+//User's saved covers
 var savedCovers = [
   new Cover("http://3.bp.blogspot.com/-iE4p9grvfpQ/VSfZT0vH2UI/AAAAAAAANq8/wwQZssi-V5g/s1600/Do%2BNot%2BForsake%2BMe%2B-%2BImage.jpg", "Sunsets and Sorrows", "sunsets", "sorrows")
 ];
-//
+//Holds cover instance
 var currentCover;
 
 
@@ -35,8 +36,8 @@ btnRandomCover.addEventListener("click", createRandomCover);
 btnViewSavedCover.addEventListener("click", showSaved);
 btnHome.addEventListener("click", returnHome);
 btnMakeMyBook.addEventListener("click", createNewCover);
-btnSaveCover.addEventListener('click', saveCover);
-viewSavedCovers.addEventListener('dblclick', deleteSavedCovers);
+btnSaveCover.addEventListener("click", saveCover);
+viewSavedCovers.addEventListener("dblclick", deleteSavedCovers);
 
 
 //Hides home view and associated buttons, displays home button
@@ -78,9 +79,9 @@ function createRandomCover() {
 //Displays Cover instance on homepage
 function displayCover(cover) {
   coverImage.src = cover.cover;
-    title.textContent = cover.title;
-    descriptor1.textContent = cover.tagline1;
-    descriptor2.textContent = cover.tagline2;
+  title.textContent = cover.title;
+  descriptor1.textContent = cover.tagline1;
+  descriptor2.textContent = cover.tagline2;
 };
 
 //Event handler for btnMakeNewCover
@@ -98,16 +99,16 @@ function showSaved() {
   formView.classList.add("hidden");
   leaveHome();
   viewSavedCovers.innerHTML = "";
-  for (var i = 0; i < savedCovers.length; i++) {
-  viewSavedCovers.innerHTML += `<section class="main-cover mini-cover">
-    <img class="cover-image" src="${savedCovers[i].cover}" id="${savedCovers[i].id}">
-    <h2 class="cover-title" id="${savedCovers[i].id}">${savedCovers[i].title}</h2>
-    <h3 class="tagline" id="${savedCovers[i].id}">A tale of <span class="tagline-1">${savedCovers[i].tagline1}</span> and <span class="tagline-2">${savedCovers[i].tagline2}</span></h3>
-    <img class="price-tag" id="${savedCovers[i].id}" src="./assets/price.png">
-    <img class="overlay" src="./assets/overlay.png">
-  </section>`;
-  };
-  };
+    for (var i = 0; i < savedCovers.length; i++) {
+    viewSavedCovers.innerHTML += `<section class="main-cover mini-cover">
+      <img class="cover-image" src="${savedCovers[i].cover}" id="${savedCovers[i].id}">
+      <h2 class="cover-title" id="${savedCovers[i].id}">${savedCovers[i].title}</h2>
+      <h3 class="tagline" id="${savedCovers[i].id}">A tale of <span class="tagline-1">${savedCovers[i].tagline1}</span> and <span class="tagline-2">${savedCovers[i].tagline2}</span></h3>
+      <img class="price-tag" id="${savedCovers[i].id}" src="./assets/price.png">
+      <img class="overlay" src="./assets/overlay.png">
+    </section>`;
+    };
+};
 
 
 //Event handler for btnMakeMyBook
@@ -128,18 +129,18 @@ function createNewCover(event) {
 
 //Checks user's cover for duplicates before adding to Saved Covers array
 function saveCover() {
-  if (!savedCovers.includes(currentCover)){
+  if (!savedCovers.includes(currentCover)) {
     savedCovers.push(currentCover);
   };
 };
 
-//Event handler for deleting cover on dblclicking 
+//Event handler for deleting cover on dblclicking
 function deleteSavedCovers(e) {
-var elementId = e.target.getAttribute("id");
-for (var i = 0; i < savedCovers.length; i++) {
- if (savedCovers[i].id == elementId) {
-  savedCovers.splice(i, 1);
+  var elementId = e.target.getAttribute("id");
+    for (var i = 0; i < savedCovers.length; i++) {
+      if (savedCovers[i].id == elementId) {
+        savedCovers.splice(i, 1);
+      };
+    };
   showSaved();
- }
-}
 };

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,7 @@ btnViewSavedCover.addEventListener("click", showSaved);
 btnHome.addEventListener("click", returnHome);
 btnMakeMyBook.addEventListener("click", createNewCover);
 btnSaveCover.addEventListener('click', saveCover);
+viewSavedCovers.addEventListener('dblclick', deleteSavedCovers);
 
 
 //Hides home view and associated buttons, displays home button


### PR DESCRIPTION
## Is this a fix or a feature?
feature

## What is the change?
We created the ability for a user to double click on a mini cover in the saved covers view, which will delete that cover from their saved covers. 

## What does it fix?
N/A

## Where should the reviewer start?
line 39 is the event listeners for a double click
lines 135-143 is our event handler for this listener

## How should this be tested?
- User should click "Make Your Own Cover" button
- Fill out the form and click the "Make My Book" button
- Click the "Save Cover" button
- Click "View Saved Covers" button
- Double click a mini cover from this area and see if it is removed
- Console Log the savedCovers array to make sure the correct cover was deleted
